### PR TITLE
Revert back to using GitHub-based codspeed runners instead of codspee…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   tests:
-    runs-on: ${{ matrix.codspeed && 'codspeed-macro' || matrix.os }}
+    runs-on: ${{ matrix.os }}
     env:
       PYTHONIOENCODING: utf-8
     steps:


### PR DESCRIPTION
…d hosted Macro runners