### PR TITLE
Remove idempotent encode-decode calls for unicode character

### DIFF
--- a/src/usethis/_console.py
+++ b/src/usethis/_console.py
@@ -35,9 +35,7 @@ def tick_print(msg: str | Exception) -> None:
     msg = str(msg)
 
     if not (usethis_config.quiet or usethis_config.alert_only):
-        console.print(
-            f"{'✔'.encode('utf-8', 'ignore').decode('utf-8')} {msg}", style="green"
-        )
+        console.print(f"✔ {msg}", style="green")
 
 
 def box_print(msg: str | Exception) -> None:


### PR DESCRIPTION
I think this was added from a contributor without testing it was necessary. It seems to have no effect, so I've removed it. In hindsight, it was fairly clear it had no effect because the other unicode characters didn't use it.

I also noticed an issue regarding missing messages when looking into this https://github.com/usethis-python/usethis-python/issues/881