### PR TITLE
Always use `--build-backend hatch` for `uv init` subprocesses from `u…

### DIFF
--- a/src/usethis/_integrations/uv/init.py
+++ b/src/usethis/_integrations/uv/init.py
@@ -19,7 +19,13 @@ def opinionated_uv_init() -> None:
     tick_print("Writing 'pyproject.toml' and initializing project.")
     try:
         call.call_uv_subprocess(
-            ["init", "--lib", usethis_config.cpd().as_posix()],
+            [
+                "init",
+                "--lib",
+                "--build-backend",
+                "hatch",
+                usethis_config.cpd().as_posix(),
+            ],
             change_toml=True,
         )
     except UVSubprocessFailedError as err:

--- a/tests/usethis/_integrations/uv/test_init.py
+++ b/tests/usethis/_integrations/uv/test_init.py
@@ -47,6 +47,14 @@ class TestOpinionatedUVInit:
         ):
             opinionated_uv_init()
 
+    def test_build_backend_is_hatch(self, tmp_path: Path):
+        # Act
+        with change_cwd(tmp_path), PyprojectTOMLManager() as manager:
+            opinionated_uv_init()
+
+            # Assert
+            assert manager[["build-system", "build-backend"]] == "hatchling.build"
+
 
 class TestEnsurePyprojectTOML:
     def test_created(self, tmp_path: Path, capfd: pytest.CaptureFixture[str]):

--- a/tests/usethis/_integrations/uv/test_init.py
+++ b/tests/usethis/_integrations/uv/test_init.py
@@ -48,8 +48,8 @@ class TestOpinionatedUVInit:
             opinionated_uv_init()
 
     def test_build_backend_is_hatch(self, tmp_path: Path):
-        # Act
         with change_cwd(tmp_path), PyprojectTOMLManager() as manager:
+            # Act
             opinionated_uv_init()
 
             # Assert


### PR DESCRIPTION
…sethis init`