### PR TITLE
Refactor Python version logic into a dedicated class

### DIFF
--- a/src/usethis/_integrations/ci/bitbucket/steps.py
+++ b/src/usethis/_integrations/ci/bitbucket/steps.py
@@ -41,7 +41,7 @@ from usethis._integrations.ci.bitbucket.schema import (
     StepItem,
 )
 from usethis._integrations.ci.bitbucket.schema_utils import step1tostep
-from usethis._integrations.environ.python import get_supported_major_python_versions
+from usethis._integrations.environ.python import get_supported_minor_python_versions
 from usethis._integrations.file.yaml.update import update_ruamel_yaml_map
 from usethis._types.backend import BackendEnum
 
@@ -171,7 +171,7 @@ def _add_step_in_default_via_doc(
     # N.B. Currently, we are not accounting for parallelism, whereas all these steps
     # could be parallel potentially.
     # See https://github.com/usethis-python/usethis-python/issues/149
-    maj_versions = get_supported_major_python_versions()
+    minor_versions = get_supported_minor_python_versions()
     step_order = [
         "Run pre-commit",
         # For these tools, sync them with the pre-commit removal logic
@@ -181,7 +181,7 @@ def _add_step_in_default_via_doc(
         "Run deptry",
         "Run Import Linter",
         "Run Codespell",
-        *[f"Test on 3.{maj_version}" for maj_version in maj_versions],
+        *[f"Test on {version.to_short_string()}" for version in minor_versions],
     ]
     for step_name in step_order:
         if step_name == step.name:

--- a/src/usethis/_integrations/environ/python.py
+++ b/src/usethis/_integrations/environ/python.py
@@ -4,19 +4,19 @@ from typing_extensions import assert_never
 
 from usethis._integrations.backend.dispatch import get_backend
 from usethis._integrations.backend.uv.python import (
-    get_supported_uv_major_python_versions,
+    get_supported_uv_minor_python_versions,
 )
-from usethis._integrations.python.version import get_python_major_version
+from usethis._integrations.python.version import PythonVersion
 from usethis._types.backend import BackendEnum
 
 
-def get_supported_major_python_versions() -> list[int]:
+def get_supported_minor_python_versions() -> list[PythonVersion]:
     backend = get_backend()
 
     if backend is BackendEnum.uv:
-        versions = get_supported_uv_major_python_versions()
+        versions = get_supported_uv_minor_python_versions()
     elif backend is BackendEnum.none:
-        versions = [get_python_major_version()]
+        versions = [PythonVersion.from_interpreter()]
     else:
         assert_never(backend)
 

--- a/src/usethis/_integrations/python/version.py
+++ b/src/usethis/_integrations/python/version.py
@@ -2,19 +2,55 @@
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from sysconfig import get_python_version as _get_python_version
 
 
-def get_python_version() -> str:
-    """Get the Python version."""
-    return _get_python_version()
+class PythonVersionParseError(ValueError):
+    """Raised when a Python version string cannot be parsed."""
 
 
-def get_python_major_version() -> int:
-    """Get the major version of Python."""
-    return extract_major_version(get_python_version())
+@dataclass(frozen=True)
+class PythonVersion:
+    """Represents a Python version with major.minor.patch components.
 
+    All components are stored as strings to handle alpha versions like 3.14.0a3.
 
-def extract_major_version(version: str) -> int:
-    """Extract the major version from a version string."""
-    return int(version.split(".")[1])
+    Examples:
+        3.10.5 → major="3", minor="10", patch="5"
+        3.13 → major="3", minor="13", patch=None
+        3.14.0a3 → major="3", minor="14", patch="0a3"
+    """
+
+    major: str
+    minor: str
+    patch: str | None = None
+
+    @classmethod
+    def from_string(cls, version: str) -> PythonVersion:
+        """Parse version string like '3.10.5' or '3.13' or '3.14.0a3'."""
+        match = re.match(r"^(\d+)\.(\d+)(?:\.(\S+))?", version)
+        if match is None:
+            msg = f"Could not parse Python version from '{version}'."
+            raise PythonVersionParseError(msg)
+
+        major = match.group(1)
+        minor = match.group(2)
+        patch = match.group(3) if match.group(3) else None
+        return cls(major=major, minor=minor, patch=patch)
+
+    def to_short_string(self) -> str:
+        """Return X.Y format (e.g., '3.10')."""
+        return f"{self.major}.{self.minor}"
+
+    def __str__(self) -> str:
+        """Return full version string."""
+        if self.patch is None:
+            return self.to_short_string()
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+    @classmethod
+    def from_interpreter(cls) -> PythonVersion:
+        """Get the Python version from the current interpreter."""
+        return cls.from_string(_get_python_version())

--- a/src/usethis/_tool/impl/pytest.py
+++ b/src/usethis/_tool/impl/pytest.py
@@ -19,12 +19,12 @@ from usethis._integrations.ci.bitbucket.schema import Script as BitbucketScript
 from usethis._integrations.ci.bitbucket.schema import Step as BitbucketStep
 from usethis._integrations.ci.bitbucket.steps import get_steps_in_default
 from usethis._integrations.ci.bitbucket.used import is_bitbucket_used
-from usethis._integrations.environ.python import get_supported_major_python_versions
+from usethis._integrations.environ.python import get_supported_minor_python_versions
 from usethis._integrations.file.pyproject_toml.io_ import PyprojectTOMLManager
 from usethis._integrations.file.setup_cfg.io_ import SetupCFGManager
 from usethis._integrations.project.build import has_pyproject_toml_declared_build_system
 from usethis._integrations.project.layout import get_source_dir_str
-from usethis._integrations.python.version import get_python_major_version
+from usethis._integrations.python.version import PythonVersion
 from usethis._tool.base import Tool
 from usethis._tool.config import ConfigEntry, ConfigItem, ConfigSpec
 from usethis._tool.rule import RuleConfig
@@ -225,9 +225,9 @@ class PytestTool(Tool):
 
     def get_bitbucket_steps(self, *, matrix_python: bool = True) -> list[BitbucketStep]:
         if matrix_python:
-            versions = get_supported_major_python_versions()
+            versions = get_supported_minor_python_versions()
         else:
-            versions = [get_python_major_version()]
+            versions = [PythonVersion.from_interpreter()]
 
         backend = get_backend()
 
@@ -235,19 +235,19 @@ class PytestTool(Tool):
         for version in versions:
             if backend is BackendEnum.uv:
                 step = BitbucketStep(
-                    name=f"Test on 3.{version}",
+                    name=f"Test on {version.to_short_string()}",
                     caches=["uv"],
                     script=BitbucketScript(
                         [
                             BitbucketScriptItemAnchor(name="install-uv"),
-                            f"uv run --python 3.{version} pytest -x --junitxml=test-reports/report.xml",
+                            f"uv run --python {version.to_short_string()} pytest -x --junitxml=test-reports/report.xml",
                         ]
                     ),
                 )
             elif backend is BackendEnum.none:
                 step = BitbucketStep(
-                    name=f"Test on 3.{version}",
-                    image=Image(ImageName(f"python:3.{version}")),
+                    name=f"Test on {version.to_short_string()}",
+                    image=Image(ImageName(f"python:{version.to_short_string()}")),
                     script=BitbucketScript(
                         [
                             BitbucketScriptItemAnchor(name="ensure-venv"),

--- a/src/usethis/_tool/impl/ruff.py
+++ b/src/usethis/_tool/impl/ruff.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from usethis._io import KeyValueFileManager
     from usethis._tool.rule import Rule, RuleConfig
 
-_RUFF_VERSION = "v0.14.9"  # Manually bump this version when necessary
+_RUFF_VERSION = "v0.14.10"  # Manually bump this version when necessary
 
 
 class RuffTool(Tool):

--- a/tests/usethis/_core/test_core_ci.py
+++ b/tests/usethis/_core/test_core_ci.py
@@ -611,7 +611,7 @@ pipelines:
             # Arrange
             monkeypatch.setattr(
                 usethis._integrations.python.version,
-                "get_python_version",
+                "_get_python_version",
                 lambda: "3.10.0",
             )
             (uv_init_dir / "tests").mkdir()
@@ -641,7 +641,7 @@ pipelines:
             # Arrange
             monkeypatch.setattr(
                 usethis._integrations.python.version,
-                "get_python_version",
+                "_get_python_version",
                 lambda: "3.11.0",
             )
             (bare_dir / "tests").mkdir()

--- a/tests/usethis/_core/test_core_tool.py
+++ b/tests/usethis/_core/test_core_tool.py
@@ -31,7 +31,7 @@ from usethis._integrations.backend.uv.link_mode import ensure_symlink_mode
 from usethis._integrations.backend.uv.toml import UVTOMLManager
 from usethis._integrations.file.pyproject_toml.io_ import PyprojectTOMLManager
 from usethis._integrations.pre_commit.hooks import _HOOK_ORDER, get_hook_ids
-from usethis._integrations.python.version import get_python_version
+from usethis._integrations.python.version import PythonVersion
 from usethis._test import change_cwd
 from usethis._tool.all_ import ALL_TOOLS
 from usethis._tool.impl.pre_commit import _SYNC_WITH_UV_VERSION
@@ -372,7 +372,9 @@ class TestCoverage:
         ):
             # Arrange
             # Set python version
-            (tmp_path / ".python-version").write_text(get_python_version())
+            (tmp_path / ".python-version").write_text(
+                str(PythonVersion.from_interpreter())
+            )
 
             with (
                 change_cwd(tmp_path),
@@ -2738,7 +2740,7 @@ def test_foo():
                 # Set the Python version to 3.10
                 monkeypatch.setattr(
                     usethis._integrations.python.version,
-                    "get_python_version",
+                    "_get_python_version",
                     lambda: "3.10.0",
                 )
 
@@ -2950,7 +2952,7 @@ pipelines:
                 # Set the Python version to 3.10
                 monkeypatch.setattr(
                     usethis._integrations.python.version,
-                    "get_python_version",
+                    "_get_python_version",
                     lambda: "3.10.0",
                 )
 

--- a/tests/usethis/_integrations/backend/uv/test_version.py
+++ b/tests/usethis/_integrations/backend/uv/test_version.py
@@ -23,7 +23,11 @@ class TestGetUVVersion:
                 == FALLBACK_UV_VERSION
             )
         except GitHubTagError as err:
-            if usethis_config.offline or "rate limit exceeded for url" in str(err):
+            if (
+                usethis_config.offline
+                or "rate limit exceeded for url" in str(err)
+                or "Read timed out." in str(err)
+            ):
                 pytest.skip(
                     "Failed to fetch GitHub tags (connection issues); skipping test"
                 )

--- a/tests/usethis/_integrations/python/test_version.py
+++ b/tests/usethis/_integrations/python/test_version.py
@@ -1,0 +1,210 @@
+"""Tests for Python version utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from usethis._integrations.python.version import (
+    PythonVersion,
+    PythonVersionParseError,
+)
+
+
+class TestPythonVersion:
+    class TestFromString:
+        def test_major_minor_only(self):
+            # Act
+            version = PythonVersion.from_string("3.13")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "13"
+            assert version.patch is None
+
+        def test_major_minor_patch(self):
+            # Act
+            version = PythonVersion.from_string("3.10.5")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "10"
+            assert version.patch == "5"
+
+        def test_alpha_version(self):
+            # Act
+            version = PythonVersion.from_string("3.14.0a3")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "14"
+            assert version.patch == "0a3"
+
+        def test_beta_version(self):
+            # Act
+            version = PythonVersion.from_string("3.13.0b1")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "13"
+            assert version.patch == "0b1"
+
+        def test_rc_version(self):
+            # Act
+            version = PythonVersion.from_string("3.12.0rc2")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "12"
+            assert version.patch == "0rc2"
+
+        def test_dev_version(self):
+            # Act
+            version = PythonVersion.from_string("3.15.0a1+dev")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "15"
+            assert version.patch == "0a1+dev"
+
+        def test_single_digit_minor(self):
+            # Act
+            version = PythonVersion.from_string("3.9.12")
+
+            # Assert
+            assert version.major == "3"
+            assert version.minor == "9"
+            assert version.patch == "12"
+
+        def test_python_2(self):
+            # Act
+            version = PythonVersion.from_string("2.7.18")
+
+            # Assert
+            assert version.major == "2"
+            assert version.minor == "7"
+            assert version.patch == "18"
+
+        def test_invalid_version_raises(self):
+            # Act & Assert
+            with pytest.raises(
+                PythonVersionParseError, match="Could not parse Python version"
+            ):
+                PythonVersion.from_string("invalid")
+
+        def test_empty_string_raises(self):
+            # Act & Assert
+            with pytest.raises(
+                PythonVersionParseError, match="Could not parse Python version"
+            ):
+                PythonVersion.from_string("")
+
+        def test_only_major_raises(self):
+            # Act & Assert
+            with pytest.raises(
+                PythonVersionParseError, match="Could not parse Python version"
+            ):
+                PythonVersion.from_string("3")
+
+    class TestToShortString:
+        def test_major_minor_only(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="13")
+
+            # Act
+            result = version.to_short_string()
+
+            # Assert
+            assert result == "3.13"
+
+        def test_with_patch(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="10", patch="5")
+
+            # Act
+            result = version.to_short_string()
+
+            # Assert
+            assert result == "3.10"
+
+        def test_with_alpha_patch(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="14", patch="0a3")
+
+            # Act
+            result = version.to_short_string()
+
+            # Assert
+            assert result == "3.14"
+
+    class TestStr:
+        def test_major_minor_only(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="13")
+
+            # Act
+            result = str(version)
+
+            # Assert
+            assert result == "3.13"
+
+        def test_with_patch(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="10", patch="5")
+
+            # Act
+            result = str(version)
+
+            # Assert
+            assert result == "3.10.5"
+
+        def test_with_alpha_patch(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="14", patch="0a3")
+
+            # Act
+            result = str(version)
+
+            # Assert
+            assert result == "3.14.0a3"
+
+    class TestEquality:
+        def test_equal_versions(self):
+            # Arrange
+            v1 = PythonVersion(major="3", minor="13", patch="5")
+            v2 = PythonVersion(major="3", minor="13", patch="5")
+
+            # Act & Assert
+            assert v1 == v2
+
+        def test_equal_versions_no_patch(self):
+            # Arrange
+            v1 = PythonVersion(major="3", minor="13")
+            v2 = PythonVersion(major="3", minor="13")
+
+            # Act & Assert
+            assert v1 == v2
+
+        def test_unequal_minor(self):
+            # Arrange
+            v1 = PythonVersion(major="3", minor="13")
+            v2 = PythonVersion(major="3", minor="12")
+
+            # Act & Assert
+            assert v1 != v2
+
+        def test_unequal_patch(self):
+            # Arrange
+            v1 = PythonVersion(major="3", minor="13", patch="5")
+            v2 = PythonVersion(major="3", minor="13", patch="4")
+
+            # Act & Assert
+            assert v1 != v2
+
+    class TestImmutability:
+        def test_frozen_dataclass(self):
+            # Arrange
+            version = PythonVersion(major="3", minor="13")
+
+            # Act & Assert
+            with pytest.raises(AttributeError):
+                version.major = "4"  # type: ignore[misc]

--- a/tests/usethis/_integrations/sonarqube/test_sonarqube_config.py
+++ b/tests/usethis/_integrations/sonarqube/test_sonarqube_config.py
@@ -5,7 +5,7 @@ import pytest
 from usethis._init import ensure_pyproject_toml
 from usethis._integrations.backend.uv.python import uv_python_pin
 from usethis._integrations.file.pyproject_toml.io_ import PyprojectTOMLManager
-from usethis._integrations.python.version import get_python_version
+from usethis._integrations.python.version import PythonVersion
 from usethis._integrations.sonarqube.config import (
     _validate_project_key,
     get_sonar_project_properties,
@@ -73,7 +73,7 @@ sonar.verbose=false
 
         with change_cwd(tmp_path), PyprojectTOMLManager():
             # Arrange
-            assert get_python_version()
+            assert str(PythonVersion.from_interpreter())
             uv_python_pin("3.10")
             ensure_pyproject_toml()
             PyprojectTOMLManager().set_value(
@@ -124,7 +124,7 @@ sonar.exclusions=tests/*
             == f"""\
 sonar.projectKey=foobar
 sonar.language=py
-sonar.python.version={get_python_version()}
+sonar.python.version={PythonVersion.from_interpreter()!s}
 sonar.sources=./
 sonar.tests=./tests
 sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/usethis/_tool/impl/test_codespell.py
+++ b/tests/usethis/_tool/impl/test_codespell.py
@@ -150,9 +150,9 @@ repos:
             )
         except GitHubTagError as err:
             if (
-                os.getenv("CI")
-                or usethis_config.offline
+                usethis_config.offline
                 or "rate limit exceeded for url" in str(err)
+                or "Read timed out." in str(err)
             ):
                 pytest.skip(
                     "Failed to fetch GitHub tags (connection issues); skipping test"

--- a/tests/usethis/_tool/impl/test_pre_commit.py
+++ b/tests/usethis/_tool/impl/test_pre_commit.py
@@ -49,7 +49,11 @@ class TestPreCommitTool:
                 owner="tsvikas", repo="sync-with-uv"
             )
         except GitHubTagError as err:
-            if usethis_config.offline or "rate limit exceeded for url" in str(err):
+            if (
+                usethis_config.offline
+                or "rate limit exceeded for url" in str(err)
+                or "Read timed out." in str(err)
+            ):
                 pytest.skip(
                     "Failed to fetch GitHub tags (connection issues); skipping test"
                 )

--- a/tests/usethis/_tool/impl/test_pyproject_fmt.py
+++ b/tests/usethis/_tool/impl/test_pyproject_fmt.py
@@ -42,7 +42,11 @@ class TestPyprojectFmtTool:
                 owner="tox-dev", repo="pyproject-fmt"
             )
         except GitHubTagError as err:
-            if usethis_config.offline or "rate limit exceeded for url" in str(err):
+            if (
+                usethis_config.offline
+                or "rate limit exceeded for url" in str(err)
+                or "Read timed out." in str(err)
+            ):
                 pytest.skip(
                     "Failed to fetch GitHub tags (connection issues); skipping test"
                 )

--- a/tests/usethis/_tool/impl/test_pytest.py
+++ b/tests/usethis/_tool/impl/test_pytest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from sysconfig import get_python_version
 
 import pytest
 
@@ -8,7 +7,7 @@ from usethis._config import usethis_config
 from usethis._config_file import files_manager
 from usethis._integrations.ci.bitbucket.steps import add_placeholder_step_in_default
 from usethis._integrations.file.pyproject_toml.io_ import PyprojectTOMLManager
-from usethis._integrations.python.version import extract_major_version
+from usethis._integrations.python.version import PythonVersion
 from usethis._test import change_cwd
 from usethis._tool.impl.pytest import PytestTool
 from usethis._types.backend import BackendEnum
@@ -186,7 +185,7 @@ version = "0.1.0"
 
             # Assert
             contents = (tmp_path / "bitbucket-pipelines.yml").read_text()
-            version = extract_major_version(get_python_version())
+            version = PythonVersion.from_interpreter()
             assert (
                 contents
                 == f"""\
@@ -203,12 +202,12 @@ definitions:
 pipelines:
     default:
       - step:
-            name: Test on 3.{version}
+            name: Test on {version.to_short_string()}
             caches:
               - uv
             script:
               - *install-uv
-              - uv run --python 3.{version} pytest -x --junitxml=test-reports/report.xml
+              - uv run --python {version.to_short_string()} pytest -x --junitxml=test-reports/report.xml
 """
             )
 

--- a/tests/usethis/_tool/impl/test_ruff.py
+++ b/tests/usethis/_tool/impl/test_ruff.py
@@ -390,7 +390,11 @@ lint.per-file-ignores."tests/**" = ["INP"]
                 owner="astral-sh", repo="ruff-pre-commit"
             )
         except GitHubTagError as err:
-            if usethis_config.offline or "rate limit exceeded for url" in str(err):
+            if (
+                usethis_config.offline
+                or "rate limit exceeded for url" in str(err)
+                or "Read timed out." in str(err)
+            ):
                 pytest.skip(
                     "Failed to fetch GitHub tags (connection issues); skipping test"
                 )

--- a/tests/usethis/_ui/interface/test_interface_ci.py
+++ b/tests/usethis/_ui/interface/test_interface_ci.py
@@ -88,7 +88,7 @@ class TestBitbucket:
 
         monkeypatch.setattr(
             usethis._integrations.python.version,
-            "get_python_version",
+            "_get_python_version",
             lambda: "3.10.0",
         )
 
@@ -166,7 +166,7 @@ pipelines:
         # Arrange
         monkeypatch.setattr(
             usethis._integrations.python.version,
-            "get_python_version",
+            "_get_python_version",
             lambda: "3.10.0",
         )
         (uv_init_dir / "tests").mkdir()


### PR DESCRIPTION
This helps reduce duplication and adds clarity around the source for the version inference.

Also, the version of Ruff is bumped here to pass tests.

Likewise, some GitHub API flakiness is now skipped for version monitoring tests