### PR TITLE
Migrate to basedpyright

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,7 +77,7 @@ The following checks run automatically via prek (pre-commit framework). All must
 9. **deptry** - Checks for missing/unused dependencies (`uv run deptry src`)
 10. **codespell** - Spell checker
 11. **import-linter** - Enforces architecture constraints (`uv run lint-imports`)
-12. **pyright** - Type checker (`uv run pyright`)
+12. **ty** - Type checker (`uv run ty`)
 
 **To run all checks manually:**
 ```bash
@@ -86,12 +86,12 @@ uv run prek run --all-files
 
 **Individual validation commands:**
 ```bash
-uv run ruff check --fix          # Linter with autofixes
+uv run ruff check --fix           # Linter with autofixes
 uv run ruff format                # Formatter
 uv run deptry src                 # Dependency checker
 uv run codespell                  # Spell checker
 uv run lint-imports               # Architecture constraints
-uv run pyright                    # Type checker
+uv run ty                         # Type checker
 ```
 
 ## Architecture & Project Structure
@@ -270,7 +270,7 @@ These instructions have been validated by running actual commands and inspecting
 | Run all checks | `uv run prek run --all-files` |
 | Format code | `uv run ruff format` |
 | Lint code | `uv run ruff check --fix` |
-| Check types | `uv run pyright` |
+| Check types | `uv run ty` |
 | Check dependencies | `uv run deptry src` |
 | Check architecture | `uv run lint-imports` |
 | Serve docs | `uv run mkdocs serve` |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         if: ${{ matrix.checks == null || matrix.checks == 'true' }}
         run: |
           uv run --frozen prek run --all-files
-          uv run --frozen pyright
+          uv run --frozen basedpyright
 
       - name: Run pytest
         uses: pavelzw/pytest-action@510c5e90c360a185039bea56ce8b3e7e51a16507 # v2.2.0

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ If you're not interested in templating automations, then [configurator](https://
 Major features planned are:
 
 - Support for automated GitHub Actions workflows ([#57](https://github.com/usethis-python/usethis-python/issues/57)), and
-- Support for a typechecker (likely Pyright, [#121](https://github.com/usethis-python/usethis-python/issues/121)).
+- Support for a typechecker (likely ty, [#838](https://github.com/usethis-python/usethis-python/issues/838)).
 
 Other features are tracked in the [GitHub Issues](https://github.com/usethis-python/usethis-python/issues) page.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,13 @@ scripts.usethis = "usethis.__main__:app"
 
 [dependency-groups]
 dev = [
+  "basedpyright>=1.36.2",
   "datamodel-code-generator[http]>=0.35.0",
   "deptry>=0.23.0",
   "import-linter>=2.3",
   "jinja2>=3.1.6",
   "prek>=0.2.23",
   "pyinstrument>=5.1.1",
-  "pyright[nodejs]>=1.1.399",
   "ruff>=0.14.3",
   "ty>=0.0.1a25",
 ]
@@ -183,6 +183,38 @@ exclude_also = [
   "@(abc\\.)?abstractmethod",
 ]
 omit = [ "*/pytest-of-*/*", "*/_temp/*" ]
+
+[tool.basedpyright]
+ignore = [ "src/usethis/_version.py" ]
+failOnWarnings = true
+reportAny = false
+reportArgumentType = false
+reportAssignmentType = false
+reportAttributeAccessIssue = false
+reportCallInDefaultInitializer = false
+reportExplicitAny = false
+reportImplicitOverride = false
+reportImplicitStringConcatenation = false
+reportImportCycles = false
+reportInvalidAbstractMethod = false
+reportMissingParameterType = false
+reportMissingTypeArgument = false
+reportMissingTypeStubs = false
+reportPrivateLocalImportUsage = false
+reportPrivateUsage = false
+reportUnannotatedClassAttribute = false
+reportUnknownArgumentType = false
+reportUnknownLambdaType = false
+reportUnknownMemberType = false
+reportUnknownParameterType = false
+reportUnknownVariableType = false
+reportUnnecessaryComparison = false
+reportUnnecessaryIsInstance = false
+reportUnnecessaryTypeIgnoreComment = false
+reportUnreachable = false
+reportUnusedFunction = false
+reportUnusedCallResult = false
+reportUnusedParameter = false
 
 [tool.ty]
 environment.python-platform = "all"

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,9 @@ backrefs==5.8 \
     --hash=sha256:c67f6638a34a5b8730812f5101376f9d41dc38c43f1fdc35cb54700f6ed4465d \
     --hash=sha256:e3a63b073867dbefd0536425f43db618578528e3896fb77be7141328642a1585
     # via mkdocs-material
+basedpyright==1.36.2 \
+    --hash=sha256:8dfd74fad77fcccc066ea0af5fd07e920b6f88cb1b403936aa78ab5aaef51526 \
+    --hash=sha256:b596b1a6e6006c7dfd483efc1d602574f238321e28f70bc66e87255784b70630
 black==25.1.0 \
     --hash=sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171 \
     --hash=sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7 \
@@ -521,10 +524,6 @@ mypy-extensions==1.0.0 \
     --hash=sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d \
     --hash=sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782
     # via black
-nodeenv==1.9.1 \
-    --hash=sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f \
-    --hash=sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9
-    # via pyright
 nodejs-wheel-binaries==22.16.0 \
     --hash=sha256:2728972d336d436d39ee45988978d8b5d963509e06f063e80fe41b203ee80b28 \
     --hash=sha256:2fffb4bf1066fb5f660da20819d754f1b424bca1b234ba0f4fa901c52e3975fb \
@@ -535,7 +534,7 @@ nodejs-wheel-binaries==22.16.0 \
     --hash=sha256:986b715a96ed703f8ce0c15712f76fc42895cf09067d72b6ef29e8b334eccf64 \
     --hash=sha256:d695832f026df3a0cf9a089d222225939de9d1b67f8f0a353b79f015aabbe7e2 \
     --hash=sha256:dbfccbcd558d2f142ccf66d8c3a098022bf4436db9525b5b8d32169ce185d99e
-    # via pyright
+    # via basedpyright
 packaging==24.2 \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
@@ -759,9 +758,6 @@ pymdown-extensions==10.19.1 \
     --hash=sha256:4969c691009a389fb1f9712dd8e7bd70dcc418d15a0faf70acb5117d022f7de8 \
     --hash=sha256:e8698a66055b1dc0dca2a7f2c9d0ea6f5faa7834a9c432e3535ab96c0c4e509b
     # via mkdocs-material
-pyright==1.1.403 \
-    --hash=sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104 \
-    --hash=sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3
 pytest==8.3.5 \
     --hash=sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820 \
     --hash=sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845
@@ -1023,7 +1019,6 @@ typing-extensions==4.15.0 \
     #   import-linter
     #   pydantic
     #   pydantic-core
-    #   pyright
     #   rich
     #   typer
     #   typing-inspection

--- a/tests/usethis/_integrations/ci/bitbucket/test_yaml.py
+++ b/tests/usethis/_integrations/ci/bitbucket/test_yaml.py
@@ -55,7 +55,7 @@ image: atlassian/default-image:3
         with change_cwd(tmp_path), BitbucketPipelinesYAMLManager() as mgr:
             doc = mgr.get()
             mgr.model_validate()
-            assert isinstance(doc.content, dict)  # Help pyright
+            assert isinstance(doc.content, dict)  # Help type checker
             doc.content["image"] = "atlassian/default-image:2"
             mgr.commit(doc)
 
@@ -84,7 +84,7 @@ pipelines:
         with change_cwd(tmp_path), BitbucketPipelinesYAMLManager() as mgr:
             doc = mgr.get()
             mgr.model_validate()
-            # Help pyright with assertions
+            # Help type checker with assertions
             assert isinstance(doc.content, dict)
             assert isinstance(doc.content["pipelines"], dict)
             assert isinstance(doc.content["pipelines"]["default"], list)

--- a/tests/usethis/_integrations/file/yaml/test_update.py
+++ b/tests/usethis/_integrations/file/yaml/test_update.py
@@ -19,7 +19,7 @@ hello: world # comment
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"hello": "world"},
@@ -43,7 +43,7 @@ hello: world # comment
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"hello": "universe"},
@@ -70,7 +70,7 @@ key:
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"key": [1, 2, 4]},
@@ -98,7 +98,7 @@ other: value
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"key": "new value"},
@@ -124,7 +124,7 @@ this: willberemoved
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"key": {"hello": "universe"}, "banana": "yummy"},
@@ -159,8 +159,8 @@ hello: 4 # yet another
 
         # Act
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedMap)  # Help pyright
-            assert isinstance(another_yaml_doc.content, CommentedMap)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedMap)
+            assert isinstance(another_yaml_doc.content, CommentedMap)
             update_ruamel_yaml_map(
                 yaml_document.content,
                 {"key": [1, another_yaml_doc.content, another_yaml_doc.content.copy()]},
@@ -382,7 +382,7 @@ class TestLCSListUpdate:
 """)
 
         with edit_yaml(path) as yaml_document:
-            assert isinstance(yaml_document.content, CommentedSeq)  # Help pyright
+            assert isinstance(yaml_document.content, CommentedSeq)
             # Act
             lcs_list_update(yaml_document.content, [1, 2, 4])
 

--- a/uv.lock
+++ b/uv.lock
@@ -58,6 +58,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/8a/4c5d74314fe085f8f9b1a92b7c96e2a116651b6c7596e4def872d5d7abf0/basedpyright-1.36.2.tar.gz", hash = "sha256:b596b1a6e6006c7dfd483efc1d602574f238321e28f70bc66e87255784b70630", size = 22835798, upload-time = "2025-12-23T02:31:27.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/88/0aaac8e5062cd83434ce41fac844646d0f285b574cda0eeb732e916db22b/basedpyright-1.36.2-py3-none-any.whl", hash = "sha256:8dfd74fad77fcccc066ea0af5fd07e920b6f88cb1b403936aa78ab5aaef51526", size = 11882631, upload-time = "2025-12-23T02:31:24.537Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -814,15 +826,6 @@ wheels = [
 ]
 
 [[package]]
-name = "nodeenv"
-version = "1.9.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437, upload-time = "2024-06-04T18:44:11.171Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314, upload-time = "2024-06-04T18:44:08.352Z" },
-]
-
-[[package]]
 name = "nodejs-wheel-binaries"
 version = "22.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1119,24 +1122,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/72/2d/9f30cee56d4d6d222430d401e85b0a6a1ae229819362f5786943d1a8c03b/pymdown_extensions-10.19.1.tar.gz", hash = "sha256:4969c691009a389fb1f9712dd8e7bd70dcc418d15a0faf70acb5117d022f7de8", size = 847839, upload-time = "2025-12-14T17:25:24.42Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/35/b763e8fbcd51968329b9adc52d188fc97859f85f2ee15fe9f379987d99c5/pymdown_extensions-10.19.1-py3-none-any.whl", hash = "sha256:e8698a66055b1dc0dca2a7f2c9d0ea6f5faa7834a9c432e3535ab96c0c4e509b", size = 266693, upload-time = "2025-12-14T17:25:22.999Z" },
-]
-
-[[package]]
-name = "pyright"
-version = "1.1.403"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/f6/35f885264ff08c960b23d1542038d8da86971c5d8c955cfab195a4f672d7/pyright-1.1.403.tar.gz", hash = "sha256:3ab69b9f41c67fb5bbb4d7a36243256f0d549ed3608678d381d5f51863921104", size = 3913526, upload-time = "2025-07-09T07:15:52.882Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/b6/b04e5c2f41a5ccad74a1a4759da41adb20b4bc9d59a5e08d29ba60084d07/pyright-1.1.403-py3-none-any.whl", hash = "sha256:c0eeca5aa76cbef3fcc271259bbd785753c7ad7bcac99a9162b4c4c7daed23b3", size = 5684504, upload-time = "2025-07-09T07:15:50.958Z" },
-]
-
-[package.optional-dependencies]
-nodejs = [
-    { name = "nodejs-wheel-binaries" },
 ]
 
 [[package]]
@@ -1599,13 +1584,13 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "basedpyright" },
     { name = "datamodel-code-generator", extra = ["http"] },
     { name = "deptry" },
     { name = "import-linter" },
     { name = "jinja2" },
     { name = "prek" },
     { name = "pyinstrument" },
-    { name = "pyright", extra = ["nodejs"] },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1644,13 +1629,13 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "basedpyright", specifier = ">=1.36.2" },
     { name = "datamodel-code-generator", extras = ["http"], specifier = ">=0.35.0" },
     { name = "deptry", specifier = ">=0.23.0" },
     { name = "import-linter", specifier = ">=2.3" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "prek", specifier = ">=0.2.23" },
     { name = "pyinstrument", specifier = ">=5.1.1" },
-    { name = "pyright", extras = ["nodejs"], specifier = ">=1.1.399" },
     { name = "ruff", specifier = ">=0.14.3" },
     { name = "ty", specifier = ">=0.0.1a25" },
 ]


### PR DESCRIPTION
Lots of rules are currently disabled but we can re-enable them gradually in follow-up PRs (see #1257)