### PR TITLE
Enable soft wrapping for `plain_print`

### DIFF
--- a/src/usethis/_console.py
+++ b/src/usethis/_console.py
@@ -32,7 +32,7 @@ def plain_print(msg: str | Exception) -> None:
         or usethis_config.alert_only
         or usethis_config.instruct_only
     ):
-        console.print(msg)
+        Console(force_terminal=False, soft_wrap=True).print(msg)
 
 
 def table_print(table: Table) -> None:

--- a/tests/usethis/test_console.py
+++ b/tests/usethis/test_console.py
@@ -29,6 +29,17 @@ class TestPlainPrint:
         out, _ = capfd.readouterr()
         assert out == "Hello\n"
 
+    def test_no_line_wrapping(self, capfd: pytest.CaptureFixture[str]) -> None:
+        # Arrange
+        long_msg = "A" * 100
+
+        # Act
+        plain_print(long_msg)
+
+        # Assert
+        out, _ = capfd.readouterr()
+        assert out == f"{long_msg}\n"
+
 
 class TestTablePrint:
     def test_out(self, capfd: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
This helps avoid invalid output from `usethis show sonarqube`