### PR TITLE
Enable `reportArgumentType` in `basedpyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,6 @@ rules.possibly-missing-attribute = "ignore"
 ignore = [ "src/usethis/_version.py" ]
 failOnWarnings = true
 reportAny = false
-reportArgumentType = false
 reportAssignmentType = false
 reportAttributeAccessIssue = false
 reportCallInDefaultInitializer = false

--- a/src/usethis/_file/toml/io_.py
+++ b/src/usethis/_file/toml/io_.py
@@ -402,7 +402,7 @@ def _set_value_in_existing(
             for key in reversed(unshared_keys[1:]):
                 contents = {key: contents}
 
-            shared_container[keys[1]] = contents  # type: ignore[reportAssignmentType]
+            shared_container[keys[1]] = contents  # pyright: ignore[reportArgumentType]
         else:
             shared_container[_get_unified_key(unshared_keys)] = value
 

--- a/tests/usethis/_file/ini/test_ini_io_.py
+++ b/tests/usethis/_file/ini/test_ini_io_.py
@@ -11,7 +11,6 @@ from usethis._file.ini.errors import (
     INIStructureError,
     INIValueAlreadySetError,
     INIValueMissingError,
-    InvalidINITypeError,
     UnexpectedINIIOError,
     UnexpectedINIOpenError,
 )
@@ -1470,26 +1469,6 @@ key2 = value2
 key = new_value
 """
             )
-
-        def test_wrong_list_type_raises(self, tmp_path: Path):
-            # Arrange
-            class MyINIFileManager(INIFileManager):
-                @property
-                def relative_path(self) -> Path:
-                    return Path("valid.ini")
-
-            valid_file = tmp_path / "valid.ini"
-            valid_file.touch()
-
-            # Act, Assert
-            with (
-                change_cwd(tmp_path),
-                MyINIFileManager() as manager,
-                pytest.raises(
-                    InvalidINITypeError, match="INI files only support strings"
-                ),
-            ):
-                manager.extend_list(keys=["section", "key"], values=[123])  # type: ignore
 
     class TestRemoveFromList:
         def test_singleton_list_collapsed(self, tmp_path: Path):

--- a/tests/usethis/_integrations/pre_commit/test_yaml.py
+++ b/tests/usethis/_integrations/pre_commit/test_yaml.py
@@ -148,10 +148,3 @@ class TestPreCommitFancyDump:
                 ),
                 reference={},
             )
-
-    def test_invalid(self):
-        with pytest.raises(TypeError):
-            _pre_commit_fancy_dump(
-                config=2,  # type: ignore for test
-                reference={},
-            )


### PR DESCRIPTION
I'm removing a couple of the tests which aren't adding value since the type checker already protects against errors.