### PR TITLE
Enable `reportPrivateLocalImportUsage` in `basedpyright`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,7 +218,6 @@ reportInvalidAbstractMethod = false
 reportMissingParameterType = false
 reportMissingTypeArgument = false
 reportMissingTypeStubs = false
-reportPrivateLocalImportUsage = false
 reportPrivateUsage = false
 reportUnannotatedClassAttribute = false
 reportUnknownArgumentType = false

--- a/src/usethis/_tool/base.py
+++ b/src/usethis/_tool/base.py
@@ -41,11 +41,11 @@ from usethis.errors import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from usethis._backend.uv.deps import Dependency
     from usethis._integrations.pre_commit import schema as pre_commit_schema
     from usethis._io import KeyValueFileManager
     from usethis._tool.config import ConfigItem, ResolutionT
     from usethis._tool.rule import Rule
+    from usethis._types.deps import Dependency
 
 
 class Tool(Protocol):

--- a/src/usethis/_tool/impl/pyproject_toml.py
+++ b/src/usethis/_tool/impl/pyproject_toml.py
@@ -18,9 +18,8 @@ from usethis._tool.impl.requirements_txt import RequirementsTxtTool
 from usethis._tool.impl.ruff import RuffTool
 
 if TYPE_CHECKING:
-    from usethis._backend.uv.deps import (
-        Dependency,
-    )
+    from usethis._types.deps import Dependency
+
 
 OTHER_TOOLS: list[Tool] = [
     CodespellTool(),

--- a/src/usethis/_tool/impl/requirements_txt.py
+++ b/src/usethis/_tool/impl/requirements_txt.py
@@ -15,9 +15,7 @@ from usethis._tool.pre_commit import PreCommitConfig
 from usethis._types.backend import BackendEnum
 
 if TYPE_CHECKING:
-    from usethis._backend.uv.deps import (
-        Dependency,
-    )
+    from usethis._types.deps import Dependency
 
 
 class RequirementsTxtTool(Tool):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,10 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from usethis._backend.uv.call import call_subprocess, call_uv_subprocess
+from usethis._backend.uv.call import call_uv_subprocess
 from usethis._config import usethis_config
 from usethis._console import _cached_warn_print, get_icon_mode
 from usethis._file.pyproject_toml.io_ import PyprojectTOMLManager
+from usethis._subprocess import call_subprocess
 from usethis._test import change_cwd, is_offline
 from usethis._tool.impl.import_linter import _importlinter_warn_no_packages_found
 

--- a/tests/usethis/_integrations/ci/bitbucket/test_steps.py
+++ b/tests/usethis/_integrations/ci/bitbucket/test_steps.py
@@ -6,12 +6,12 @@ from usethis._config import usethis_config
 from usethis._config_file import files_manager
 from usethis._integrations.ci.bitbucket import schema
 from usethis._integrations.ci.bitbucket.anchor import ScriptItemAnchor
+from usethis._integrations.ci.bitbucket.errors import UnexpectedImportPipelineError
 from usethis._integrations.ci.bitbucket.init import (
     ensure_bitbucket_pipelines_config_exists,
 )
 from usethis._integrations.ci.bitbucket.steps import (
     _CACHE_LOOKUP,
-    UnexpectedImportPipelineError,
     _add_step_caches_via_model,
     add_bitbucket_step_in_default,
     add_placeholder_step_in_default,

--- a/tests/usethis/_integrations/ci/github/test_tags.py
+++ b/tests/usethis/_integrations/ci/github/test_tags.py
@@ -1,9 +1,11 @@
 import pytest
 from requests.exceptions import HTTPError
 
-from usethis._integrations.ci.github.tags import (
+from usethis._integrations.ci.github.errors import (
     GitHubTagError,
     NoGitHubTagsFoundError,
+)
+from usethis._integrations.ci.github.tags import (
     get_github_latest_tag,
 )
 


### PR DESCRIPTION
This is a particularly nice rule, stylistically, because it catches rotten import locations/homes